### PR TITLE
Use correct filename for Attachments.

### DIFF
--- a/example/example/src/ExampleActions.scala
+++ b/example/example/src/ExampleActions.scala
@@ -27,13 +27,13 @@ object ExampleActions {
     } yield ()
 
   private val pleaseAttach: BotAction = ctx =>
-    ctx.replyAttachment(title = "find-love-attached.txt", contents = "<3")
+    ctx.replyAttachment(filename = "find-love-attached.txt", title = "Con amor desde Neza, para el mundo", contents = "<3")
 
   private val fetchAndPrintAttachment: BotAction = ctx =>
     for {
       fileContent <- ctx.message.attachment
       _ <- ctx.message.content match {
-        case a: ContentOfAttachment => ctx.replyAttachment(a.attachment.`object`.filename, fileContent)
+        case a: ContentOfAttachment => ctx.replyAttachment(a.attachment.`object`.filename, a.attachment.`object`.filename, fileContent)
       }
     } yield ()
 

--- a/keybase/src/Schemas.scala
+++ b/keybase/src/Schemas.scala
@@ -25,7 +25,11 @@ object CommandFailed {
 trait MessageContext {
   val message: Message
   def replyMessage(message: String): ZIO[Console, CommandFailed, Unit]
-  def replyAttachment(title: String, contents: os.Source): ZIO[Console with Blocking, CommandFailed, Unit]
+  def replyAttachment(
+      filename: String,
+      title: String,
+      contents: os.Source
+  ): ZIO[Console with Blocking, CommandFailed, Unit]
 }
 
 case class Channel(


### PR DESCRIPTION
Previously attachments were sent using a random tmp filename. Now people should specify the correct filename.